### PR TITLE
Detect platform to avoid requiring a parameter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,12 @@ commands:
     steps:
       - checkout
       - kube-orb/install
+      - run:
+          name: Test kops
+          command: kops version
+      - run:
+          name: Test kubectl
+          command: kubectl
 
 jobs:
   integration-test-docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,10 @@ executors:
   machine:
     machine: true
 
+  macos:
+    macos:
+      xcode: "10.1.0"
+
 commands:
   integration-tests:
     steps:
@@ -29,6 +33,11 @@ jobs:
     steps:
       - integration-tests
 
+  integration-test-macos:
+    executor: macos
+    steps:
+      - integration-tests
+
 # yaml anchor filters
 integration-dev_filters: &integration-dev_filters
   branches:
@@ -43,7 +52,7 @@ integration-master_filters: &integration-master_filters
     only: /master-.*/
 
 prod-deploy_requires: &prod-deploy_requires
-  [integration-test-docker-master, integration-test-machine-master]
+  [integration-test-docker-master, integration-test-machine-master, integration-test-macos-master]
 
 workflows:
   lint_pack-validate_publish-dev:
@@ -94,6 +103,11 @@ workflows:
           context: orb-publishing
           filters: *integration-dev_filters
 
+      - integration-test-macos:
+          name: integration-test-macos-dev
+          context: orb-publishing
+          filters: *integration-dev_filters
+
       # master-branch
       - integration-test-docker:
           name: integration-test-docker-master
@@ -102,6 +116,11 @@ workflows:
 
       - integration-test-machine:
           name: integration-test-machine-master
+          context: orb-publishing
+          filters: *integration-master_filters
+
+      - integration-test-macos:
+          name: integration-test-macos-master
           context: orb-publishing
           filters: *integration-master_filters
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,7 +78,7 @@ workflows:
       - orb-tools/trigger-integration-workflow:
           name: trigger-integration-dev
           context: orb-publishing
-          ssh-fingerprints:   1b:26:fb:58:c5:a1:95:ef:13:93:11:4e:dd:42:41:2d
+          ssh-fingerprints: 1b:26:fb:58:c5:a1:95:ef:13:93:11:4e:dd:42:41:2d
           requires:
             - orb-tools/publish-dev
           filters:
@@ -88,7 +88,7 @@ workflows:
       - orb-tools/trigger-integration-workflow:
           name: trigger-integration-master
           context: orb-publishing
-          ssh-fingerprints:   1b:26:fb:58:c5:a1:95:ef:13:93:11:4e:dd:42:41:2d
+          ssh-fingerprints: 1b:26:fb:58:c5:a1:95:ef:13:93:11:4e:dd:42:41:2d
           tag: master
           requires:
             - orb-tools/publish-dev

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -3,12 +3,6 @@ description: |
   Requirements: curl, amd64 architecture
 
 parameters:
-  platform:
-    description: |
-      The platform on which to install kops and kubectl
-    type: enum
-    default: "linux"
-    enum: ["linux", "darwin"]
   kops-version:
     type: string
     default: "latest"
@@ -27,14 +21,19 @@ steps:
           KOPS_VERSION=<<parameters.kops-version>>
         fi
 
+        PLATFORM="linux"
+        if [ -n "$(uname | grep "Darwin")" ]; then
+          PLATFORM="darwin"
+        fi
+
         # download kops
-        curl -LO https://github.com/kubernetes/kops/releases/download/$KOPS_VERSION/kops-<<parameters.platform>>-amd64
+        curl -LO https://github.com/kubernetes/kops/releases/download/$KOPS_VERSION/kops-$PLATFORM-amd64
 
-        sudo chmod +x kops-<<parameters.platform>>-amd64 || \
-          chmod +x kops-<<parameters.platform>>-amd64
+        sudo chmod +x kops-$PLATFORM-amd64 || \
+          chmod +x kops-$PLATFORM-amd64
 
-        sudo mv kops-<<parameters.platform>>-amd64 /usr/local/bin/kops || \
-          mv kops-<<parameters.platform>>-amd64 /usr/local/bin/kops
+        sudo mv kops-$PLATFORM-amd64 /usr/local/bin/kops || \
+          mv kops-$PLATFORM-amd64 /usr/local/bin/kops
 
   - run:
       name: Install kubectl
@@ -47,7 +46,7 @@ steps:
         fi
 
         # download kubectl
-        curl -LO https://storage.googleapis.com/kubernetes-release/release/$KUBECTL_VERSION/bin/<<parameters.platform>>/amd64/kubectl
+        curl -LO https://storage.googleapis.com/kubernetes-release/release/$KUBECTL_VERSION/bin/$PLATFORM/amd64/kubectl
 
         sudo chmod +x ./kubectl || \
           chmod +x ./kubectl

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -29,11 +29,11 @@ steps:
         # download kops
         curl -LO https://github.com/kubernetes/kops/releases/download/$KOPS_VERSION/kops-$PLATFORM-amd64
 
-        sudo chmod +x kops-$PLATFORM-amd64 || \
-          chmod +x kops-$PLATFORM-amd64
+        [ -w /usr/local/bin ] && SUDO="" || SUDO=sudo
+        
+        $SUDO chmod +x kops-$PLATFORM-amd64
 
-        sudo mv kops-$PLATFORM-amd64 /usr/local/bin/kops || \
-          mv kops-$PLATFORM-amd64 /usr/local/bin/kops
+        $SUDO mv kops-$PLATFORM-amd64 /usr/local/bin/kops
 
   - run:
       name: Install kubectl
@@ -52,9 +52,9 @@ steps:
 
         # download kubectl
         curl -LO https://storage.googleapis.com/kubernetes-release/release/$KUBECTL_VERSION/bin/$PLATFORM/amd64/kubectl
+        
+        [ -w /usr/local/bin ] && SUDO="" || SUDO=sudo
 
-        sudo chmod +x ./kubectl || \
-          chmod +x ./kubectl
+        $SUDO chmod +x ./kubectl
 
-        sudo mv ./kubectl /usr/local/bin || \
-          mv ./kubectl /usr/local/bin
+        $SUDO mv ./kubectl /usr/local/bin

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -30,7 +30,7 @@ steps:
         curl -LO https://github.com/kubernetes/kops/releases/download/$KOPS_VERSION/kops-$PLATFORM-amd64
 
         [ -w /usr/local/bin ] && SUDO="" || SUDO=sudo
-        
+
         $SUDO chmod +x kops-$PLATFORM-amd64
 
         $SUDO mv kops-$PLATFORM-amd64 /usr/local/bin/kops
@@ -52,7 +52,7 @@ steps:
 
         # download kubectl
         curl -LO https://storage.googleapis.com/kubernetes-release/release/$KUBECTL_VERSION/bin/$PLATFORM/amd64/kubectl
-        
+
         [ -w /usr/local/bin ] && SUDO="" || SUDO=sudo
 
         $SUDO chmod +x ./kubectl

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -45,6 +45,11 @@ steps:
           KUBECTL_VERSION=<<parameters.kubectl-version>>
         fi
 
+        PLATFORM="linux"
+        if [ -n "$(uname | grep "Darwin")" ]; then
+          PLATFORM="darwin"
+        fi
+
         # download kubectl
         curl -LO https://storage.googleapis.com/kubernetes-release/release/$KUBECTL_VERSION/bin/$PLATFORM/amd64/kubectl
 

--- a/src/examples/install.yml
+++ b/src/examples/install.yml
@@ -14,5 +14,4 @@ usage:
       steps:
         - checkout
 
-        - kube-orb/install:
-            platform: darwin
+        - kube-orb/install


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

Avoid having to pass in a parameter to specify a platform

### Description

Try to detect if the build is running on a Linux or MacOS platform, to avoid the need for a parameter
