### PR TITLE
Refactor install commands

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ commands:
   integration-tests:
     steps:
       - checkout
-      - kube-orb/install-kops
+      - kube-orb/install
       - run:
           name: Test kops
           command: kops version

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ commands:
   integration-tests:
     steps:
       - checkout
-      - kube-orb/install
+      - kube-orb/install-kops
       - run:
           name: Test kops
           command: kops version
@@ -63,7 +63,7 @@ jobs:
     executor: minikube
     steps:
       - checkout
-      - kube-orb/install
+      - kube-orb/install-kubectl
       - start-minikube
       - kube-orb/create-or-update-resource:
           resource-file-path: "tests/nginx-deployment/deployment.yaml"

--- a/src/commands/install-kops.yml
+++ b/src/commands/install-kops.yml
@@ -1,0 +1,33 @@
+description: |
+  Installs kops (latest release, by default)
+  Requirements: curl, amd64 architecture
+
+parameters:
+  kops-version:
+    type: string
+    default: "latest"
+
+steps:
+  - run:
+      name: Install kops
+      command: |
+        if [[ <<parameters.kops-version>> == "latest" ]]; then
+          # get latest kops release
+          KOPS_VERSION=$(curl -s https://api.github.com/repos/kubernetes/kops/releases/latest | grep tag_name | cut -d '"' -f 4)
+        else
+          KOPS_VERSION=<<parameters.kops-version>>
+        fi
+
+        PLATFORM="linux"
+        if [ -n "$(uname | grep "Darwin")" ]; then
+          PLATFORM="darwin"
+        fi
+
+        # download kops
+        curl -LO https://github.com/kubernetes/kops/releases/download/$KOPS_VERSION/kops-$PLATFORM-amd64
+
+        [ -w /usr/local/bin ] && SUDO="" || SUDO=sudo
+
+        $SUDO chmod +x kops-$PLATFORM-amd64
+
+        $SUDO mv kops-$PLATFORM-amd64 /usr/local/bin/kops

--- a/src/commands/install-kubectl.yml
+++ b/src/commands/install-kubectl.yml
@@ -1,40 +1,13 @@
 description: |
-  Installs kubectl and kops (latest releases, by default)
+  Installs kubectl (latest release, by default)
   Requirements: curl, amd64 architecture
 
 parameters:
-  kops-version:
-    type: string
-    default: "latest"
   kubectl-version:
     type: string
     default: "latest"
 
 steps:
-  - run:
-      name: Install kops
-      command: |
-        if [[ <<parameters.kops-version>> == "latest" ]]; then
-          # get latest kops release
-          KOPS_VERSION=$(curl -s https://api.github.com/repos/kubernetes/kops/releases/latest | grep tag_name | cut -d '"' -f 4)
-        else
-          KOPS_VERSION=<<parameters.kops-version>>
-        fi
-
-        PLATFORM="linux"
-        if [ -n "$(uname | grep "Darwin")" ]; then
-          PLATFORM="darwin"
-        fi
-
-        # download kops
-        curl -LO https://github.com/kubernetes/kops/releases/download/$KOPS_VERSION/kops-$PLATFORM-amd64
-
-        [ -w /usr/local/bin ] && SUDO="" || SUDO=sudo
-
-        $SUDO chmod +x kops-$PLATFORM-amd64
-
-        $SUDO mv kops-$PLATFORM-amd64 /usr/local/bin/kops
-
   - run:
       name: Install kubectl
       command: |

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -11,10 +11,5 @@ parameters:
     default: "latest"
 
 steps:
-  - run:
-      name: Install kops
-      command: install-kops
-
-  - run:
-      name: Install kubectl
-      command: install-kubectl
+  - install-kops
+  - install-kubectl

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -1,0 +1,20 @@
+description: |
+  Installs kubectl and kops (latest releases, by default)
+  Requirements: curl, amd64 architecture
+
+parameters:
+  kops-version:
+    type: string
+    default: "latest"
+  kubectl-version:
+    type: string
+    default: "latest"
+
+steps:
+  - run:
+      name: Install kops
+      command: install-kops
+
+  - run:
+      name: Install kubectl
+      command: install-kubectl

--- a/src/examples/deployment.yml
+++ b/src/examples/deployment.yml
@@ -15,7 +15,7 @@ usage:
         CHANGE_MINIKUBE_NONE_USER=true
       steps:
         - checkout
-        - kube-orb/install
+        - kube-orb/install-kubectl
         - run:
             name: Start minikube
             command: |

--- a/src/examples/install.yml
+++ b/src/examples/install.yml
@@ -14,4 +14,4 @@ usage:
       steps:
         - checkout
 
-        - kube-orb/install
+        - kube-orb/install-kubectl

--- a/src/examples/install.yml
+++ b/src/examples/install.yml
@@ -13,5 +13,4 @@ usage:
         xcode: "9.0"
       steps:
         - checkout
-
-        - kube-orb/install-kubectl
+        - kube-orb/install


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

Refactors the install command to separate kops from kubectl as requested in 
#5.

### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->

Refactors the install command to separate `install-kops` from `install-kubectl` commands.

Closes #5.