### PR TITLE
feat: add kubeconfig installation command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ orbs:
 executors:
   ci-base:
     docker:
-      - image: cibuilds/base
+      - image: cimg/base
 
   machine:
     machine: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,6 +42,12 @@ commands:
       - run:
           name: Test kubectl
           command: kubectl
+      - kube-orb/install-kubeconfig:
+          kubeconfig: dGVzdA==
+      - run:
+          name: Test kubeconfig output
+          command: |
+            [[ -f $HOME/.kube/config && ! -z $HOME/.kube/config && $(<$HOME/.kube/config) == "test" ]]
 
 jobs:
   integration-test-docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ commands:
           name: Test kubectl
           command: kubectl
       - kube-orb/install-kubeconfig:
-          kubeconfig: dGVzdA==
+          kubeconfig: KUBECONFIG
       - run:
           name: Test kubeconfig output
           command: |

--- a/src/commands/install-kubeconfig.yml
+++ b/src/commands/install-kubeconfig.yml
@@ -2,14 +2,15 @@ description: Install kubeconfig file
 
 parameters:
   kubeconfig:
-    type: string
-    default: base64 encoded kubconfig file
+    type: env_var_name
+    description: Environment variable name containing base64 encoded kubeconfig file
+    default: KUBECONFIG
 
 steps:
   - run:
       name: Install kubeconfig
       command: |
-        if [[ -n <<parameters.kubeconfig>> ]]; then
+        if [[ -n ${<<parameters.kubeconfig>>} ]]; then
           mkdir -p $HOME/.kube
-          echo -n <<parameters.kubeconfig>> | base64 -d > $HOME/.kube/config
+          echo -n ${<<parameters.kubeconfig>>} | base64 -d > $HOME/.kube/config
         fi

--- a/src/commands/install-kubeconfig.yml
+++ b/src/commands/install-kubeconfig.yml
@@ -10,7 +10,7 @@ steps:
   - run:
       name: Install kubeconfig
       command: |
-        if [[ -n ${<<parameters.kubeconfig>>} ]]; then
+        if [ -n "${<<parameters.kubeconfig>>}" ]; then
           mkdir -p $HOME/.kube
-          echo -n ${<<parameters.kubeconfig>>} | base64 -d > $HOME/.kube/config
+          echo -n "${<<parameters.kubeconfig>>}" | base64 -d > $HOME/.kube/config
         fi

--- a/src/commands/install-kubeconfig.yml
+++ b/src/commands/install-kubeconfig.yml
@@ -1,0 +1,14 @@
+description: Install kubeconfig file
+
+parameters:
+  kubeconfig:
+    type: string
+    default: base64 encoded kubconfig file
+
+steps:
+  - run:
+      name: Install kubeconfig
+      command: |
+        if [[ -n <<parameters.kubeconfig>> ]]; then
+          echo -n <<parameters.kubeconfig>> | base64 -d > $HOME/.kube/config
+        fi

--- a/src/commands/install-kubeconfig.yml
+++ b/src/commands/install-kubeconfig.yml
@@ -10,5 +10,6 @@ steps:
       name: Install kubeconfig
       command: |
         if [[ -n <<parameters.kubeconfig>> ]]; then
+          mkdir -p $HOME/.kube
           echo -n <<parameters.kubeconfig>> | base64 -d > $HOME/.kube/config
         fi

--- a/src/commands/install-kubeconfig.yml
+++ b/src/commands/install-kubeconfig.yml
@@ -12,5 +12,5 @@ steps:
       command: |
         if [ -n "${<<parameters.kubeconfig>>}" ]; then
           mkdir -p $HOME/.kube
-          echo -n "${<<parameters.kubeconfig>>}" | base64 -d > $HOME/.kube/config
+          echo -n "${<<parameters.kubeconfig>>}" | base64 --decode > $HOME/.kube/config
         fi

--- a/src/examples/install-kubeconfig.yml
+++ b/src/examples/install-kubeconfig.yml
@@ -15,4 +15,4 @@ usage:
         - checkout
 
         - kube-orb/install-kubeconfig:
-            kubeconfig: REZqMTg5MHVm...YWg4OTE0QWRmajkwMQ==
+            kubeconfig: KUBECONFIG

--- a/src/examples/install-kubeconfig.yml
+++ b/src/examples/install-kubeconfig.yml
@@ -13,6 +13,5 @@ usage:
         xcode: "9.0"
       steps:
         - checkout
-
         - kube-orb/install-kubeconfig:
             kubeconfig: KUBECONFIG

--- a/src/examples/install-kubeconfig.yml
+++ b/src/examples/install-kubeconfig.yml
@@ -1,0 +1,18 @@
+description: |
+  Install kubeconfig
+
+usage:
+  version: 2.1
+
+  orbs:
+    kube-orb: circleci/kubernetes@1.0.0
+
+  jobs:
+    build:
+      macos:
+        xcode: "9.0"
+      steps:
+        - checkout
+
+        - kube-orb/install-kubeconfig:
+            kubeconfig: REZqMTg5MHVm...YWg4OTE0QWRmajkwMQ==


### PR DESCRIPTION
This PR take into account the other PR #6 

### Checklist
- [X] All new jobs, commands, executors, parameters have descriptions
- [X] Examples have been added for any significant new features
- [X] README has been updated, if necessary

### Motivation, issues
It is really useful to be able to specify the cluster connection parameter via environment variable.

### Description

Add `install-kubeconfig` command which use kubeconfig parameter as a base64 encoded string representing a kubeconfig file.

Closes #7 