### PR TITLE
Fix updating of multiple container images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ executors:
 
   minikube:
     machine:
-      image: circleci/classic:201808-01
+      image: ubuntu-1604:201903-01
     environment:
       CHANGE_MINIKUBE_NONE_USER=true
 
@@ -72,7 +72,7 @@ jobs:
           show-kubectl-command: true
       - kube-orb/update-container-image:
           resource-name: "deployment/nginx-deployment"
-          container-image-updates: "nginx=nginx:1.9.1"
+          container-image-updates: "nginx=nginx:1.9.1 redis=redis:5-buster"
           record: true
       - kube-orb/get-rollout-status:
           resource-name: "deployment/nginx-deployment"

--- a/src/commands/update-container-image.yml
+++ b/src/commands/update-container-image.yml
@@ -93,7 +93,7 @@ steps:
           exit 1
         fi
         if [ -n "${CONTAINER_IMAGE_UPDATES}" ]; then
-          set -- "$@" "${CONTAINER_IMAGE_UPDATES}"
+          set -- "$@" ${CONTAINER_IMAGE_UPDATES}
         fi
         if [ -n "${NAMESPACE}" ]; then
           set -- "$@" --namespace="${NAMESPACE}"

--- a/tests/nginx-deployment/deployment.yaml
+++ b/tests/nginx-deployment/deployment.yaml
@@ -17,3 +17,8 @@ spec:
         image: nginx:1.7.9
         ports:
         - containerPort: 80
+      # For multi-image update testing purposes
+      - name: redis
+        image: redis:latest
+        ports:
+        - containerPort: 6379


### PR DESCRIPTION
Fix for issue https://github.com/CircleCI-Public/kubernetes-orb/issues/10
- allow updating of multiple container images to work correctly
- update integration test so that it tests that setting of multiple container images is possible with the fix

Also use a newer version of machine image (unrelated to fix)

### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

Resolves https://github.com/CircleCI-Public/kubernetes-orb/issues/10

### Description

Remove unnecessary surrounding quotes around the container images.
With the current bug, specifying `nginx:latest redis=redis:5-buster` as the `container-image-updates` parameter value results in a command like`kubectl set image deployment/nginx-deployment 'nginx:latest redis=redis:5-buster'` which causes the container images to be incorrectly updated.

The command needs to be expressed as `kubectl set image deployment/nginx-deployment nginx:latest redis=redis:5-buster` instead for the updates to work correctly.
