### PR TITLE
Fix ignored parameters in install command in version 0.5.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,12 @@ commands:
           command: kops version | grep "1.12.2"
       - run:
           name: Test kubectl version
-          command: kubectl version | grep "v1.15.2"
+          command: |
+            set +e
+            # ignore connection refused error
+            KUBECTL_VERSION=$(kubectl version)
+            set -e
+            echo $KUBECTL_VERSION | grep "v1.15.2"
 
 jobs:
   integration-test-docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,6 +42,18 @@ commands:
       - run:
           name: Test kubectl
           command: kubectl
+  integration-tests-specific-version:
+    steps:
+      - checkout
+      - kube-orb/install:
+          kubectl-version: v1.15.2
+          kops-version: 1.12.2
+      - run:
+          name: Test kops version
+          command: kops version | grep "1.12.2"
+      - run:
+          name: Test kubectl version
+          command: kubectl version | grep "v1.15.2"
 
 jobs:
   integration-test-docker:
@@ -52,7 +64,7 @@ jobs:
   integration-test-machine:
     executor: machine
     steps:
-      - integration-tests
+      - integration-tests-specific-version
 
   integration-test-macos:
     executor: macos

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -11,5 +11,7 @@ parameters:
     default: "latest"
 
 steps:
-  - install-kops
-  - install-kubectl
+  - install-kops:
+      kops-version: << parameters.kops-version >>
+  - install-kubectl:
+      kubectl-version: << parameters.kubectl-version >>

--- a/src/examples/deployment.yml
+++ b/src/examples/deployment.yml
@@ -5,7 +5,7 @@ usage:
   version: 2.1
 
   orbs:
-    kube-orb: circleci/kubernetes@1.0.0
+    kube-orb: circleci/kubernetes@x.y.z
 
   jobs:
     build:

--- a/src/examples/install-kops.yml
+++ b/src/examples/install-kops.yml
@@ -1,5 +1,5 @@
 description: |
-  Install kops and kubectl
+  Install kops
 
 usage:
   version: 2.1
@@ -13,4 +13,4 @@ usage:
         xcode: "9.0"
       steps:
         - checkout
-        - kube-orb/install
+        - kube-orb/install-kops

--- a/src/examples/install-kubectl.yml
+++ b/src/examples/install-kubectl.yml
@@ -1,5 +1,5 @@
 description: |
-  Install kops and kubectl
+  Install kubectl
 
 usage:
   version: 2.1
@@ -13,4 +13,4 @@ usage:
         xcode: "9.0"
       steps:
         - checkout
-        - kube-orb/install
+        - kube-orb/install-kubectl


### PR DESCRIPTION
This fixes an issue in the `install` command of version 0.5.0 (https://github.com/CircleCI-Public/kubernetes-orb/pull/6) where the `kops-version` and `kubectl-version` parameters are ignored.

Also adds examples and updates the version of kubernetes orb used in the examples (currently set to 1.0.0 which doesn't exist)