### PR TITLE
Delete resource kustomize

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,6 +120,11 @@ jobs:
           kustomize: true
           get-rollout-status: true
           show-kubectl-command: true
+      - kube-orb/delete-resource:
+          resource-file-path: "tests/kustomize/overlays/staging"
+          kustomize: true
+          now: true
+          wait: true
 # yaml anchor filters
 integration-dev_filters: &integration-dev_filters
   branches:

--- a/src/commands/delete-resource.yml
+++ b/src/commands/delete-resource.yml
@@ -91,6 +91,11 @@ parameters:
       Whether the kubectl command will be executed in dry-run mode.
     type: boolean
     default: false
+  kustomize:
+    description: |
+      Enable it to run the kubectl command with the option -k for kustomize.
+    type: boolean
+    default: false
   show-kubectl-command:
     description: |
       Whether to show the kubectl command used.
@@ -114,8 +119,13 @@ steps:
         WAIT="<< parameters.wait >>"
         NAMESPACE="<< parameters.namespace >>"
         DRY_RUN="<< parameters.dry-run >>"
+        KUSTOMIZE="<< parameters.kustomize >>"
         if [ -n "${RESOURCE_FILE_PATH}" ]; then
-          set -- "$@" -f
+          if [ "${KUSTOMIZE}" == "true" ]; then
+            set -- "$@" -k
+          else    
+            set -- "$@" -f
+          fi
           set -- "$@" "${RESOURCE_FILE_PATH}"
         elif [ -n "${RESOURCE_TYPES}" ]; then
           set -- "$@" "${RESOURCE_TYPES}"

--- a/src/commands/delete-resource.yml
+++ b/src/commands/delete-resource.yml
@@ -123,7 +123,7 @@ steps:
         if [ -n "${RESOURCE_FILE_PATH}" ]; then
           if [ "${KUSTOMIZE}" == "true" ]; then
             set -- "$@" -k
-          else    
+          else
             set -- "$@" -f
           fi
           set -- "$@" "${RESOURCE_FILE_PATH}"


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [X] All new jobs, commands, executors, parameters have descriptions
- [X] Examples have been added for any significant new features
- [X] README has been updated, if necessary

### Motivation, issues

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->
As long as kubectl now supports kustomize I find it insteresting to add this option to the orb
### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->
Added a boolean parameter kustomize to command delete resource (default value false)
If kustomize is enabled use -k instead of -f at kubectl delete command