### PR TITLE
Fix build issues

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,10 @@ orbs:
 executors:
   ci-base:
     docker:
-      - image: cimg/base
+      - image: cimg/base:stable
+        environment:
+          # For testing the install-kubeconfig command
+          KUBECONFIG: dGVzdA==
 
   machine:
     machine: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,9 +8,6 @@ executors:
   ci-base:
     docker:
       - image: cimg/base:stable
-        environment:
-          # For testing the install-kubeconfig command
-          KUBECONFIG: dGVzdA==
 
   machine:
     machine: true
@@ -72,6 +69,9 @@ commands:
 jobs:
   integration-test-docker:
     executor: ci-base
+    environment:
+      # For testing the install-kubeconfig command
+      KUBECONFIG: dGVzdA==
     steps:
       - integration-tests
 
@@ -82,6 +82,9 @@ jobs:
 
   integration-test-macos:
     executor: macos
+    environment:
+      # For testing the install-kubeconfig command
+      KUBECONFIG: dGVzdA==
     steps:
       - integration-tests
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Kubernetes Orb [![CircleCI status](https://circleci.com/gh/CircleCI-Public/kubernetes-orb.svg "CircleCI status")](https://circleci.com/gh/CircleCI-Public/kubernetes-orb) [![CircleCI Orb Version](https://img.shields.io/badge/endpoint.svg?url=https://badges.circleci.io/orb/circleci/kubernetes)](https://circleci.com/orbs/registry/orb/circleci/kubernetes) [![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/circleci-public/kubernetes-orb/master/LICENSE) [![CircleCI Community](https://img.shields.io/badge/community-CircleCI%20Discuss-343434.svg)](https://discuss.circleci.com/c/ecosystem/orbs)
 
-Tools for working with Kubernetes on CircleCI. The orb currently supports installing the `kubectl` and `kops` CLI tools and using `kubectl` for resource deployments. Separate orbs for working with Google Kubernetes Engine and other cloud providers' Kubernetes solutions are forthcoming, and this orb will be further built out, as well.
+Tools for working with Kubernetes on CircleCI. The orb currently supports installing the `kubectl` and `kops` CLI tools and using `kubectl` for resource deployments. Separate orbs for working with Google Kubernetes Engine and other cloud providers' Kubernetes solutions also exist.
 
 ## Usage
 


### PR DESCRIPTION
Fix build being broken due to:
- latest minikube version (1.4) failing when KUBECONFIG env var has an invalid value
- missing cimg/base:latest tag