### PR TITLE
Rename default env var for install kubeconfig

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -179,6 +179,8 @@ workflows:
           context: orb-publishing
           ssh-fingerprints: 1b:26:fb:58:c5:a1:95:ef:13:93:11:4e:dd:42:41:2d
           tag: master
+          use-git-diff: false
+          static-release-type: minor
           requires:
             - orb-tools/publish-dev
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ commands:
           name: Test kubectl
           command: kubectl
       - kube-orb/install-kubeconfig:
-          kubeconfig: KUBECONFIG
+          kubeconfig: KUBECONFIG_DATA
       - run:
           name: Test kubeconfig output
           command: |
@@ -71,7 +71,7 @@ jobs:
     executor: ci-base
     environment:
       # For testing the install-kubeconfig command
-      KUBECONFIG: dGVzdA==
+      KUBECONFIG_DATA: dGVzdA==
     steps:
       - integration-tests
 
@@ -84,7 +84,7 @@ jobs:
     executor: macos
     environment:
       # For testing the install-kubeconfig command
-      KUBECONFIG: dGVzdA==
+      KUBECONFIG_DATA: dGVzdA==
     steps:
       - integration-tests
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ commands:
           name: Test kubectl
           command: kubectl
       - kube-orb/install-kubeconfig:
-          kubeconfig: KUBECONFIG_DATA
+          kubeconfig: MY_KUBECONFIG_DATA
       - run:
           name: Test kubeconfig output
           command: |
@@ -65,18 +65,26 @@ commands:
             KUBECTL_VERSION=$(kubectl version)
             set -e
             echo $KUBECTL_VERSION | grep "v1.15.2"
+      - kube-orb/install-kubeconfig
+      - run:
+          name: Test kubeconfig output
+          command: |
+            [[ -f $HOME/.kube/config && ! -z $HOME/.kube/config && $(<$HOME/.kube/config) == "test" ]]
 
 jobs:
   integration-test-docker:
     executor: ci-base
     environment:
       # For testing the install-kubeconfig command
-      KUBECONFIG_DATA: dGVzdA==
+      MY_KUBECONFIG_DATA: dGVzdA==
     steps:
       - integration-tests
 
   integration-test-machine:
     executor: machine
+    environment:
+      # For testing the install-kubeconfig command
+      KUBECONFIG_DATA: dGVzdA==
     steps:
       - integration-tests-specific-version
 
@@ -84,7 +92,7 @@ jobs:
     executor: macos
     environment:
       # For testing the install-kubeconfig command
-      KUBECONFIG_DATA: dGVzdA==
+      MY_KUBECONFIG_DATA: dGVzdA==
     steps:
       - integration-tests
 

--- a/src/commands/install-kubeconfig.yml
+++ b/src/commands/install-kubeconfig.yml
@@ -1,10 +1,13 @@
-description: Install kubeconfig file
+description: |
+  Install kubeconfig file with the contents taken from the value of an
+  environment variable, which should be base64-encoded.
+
 
 parameters:
   kubeconfig:
     type: env_var_name
-    description: Environment variable name containing base64 encoded kubeconfig file
-    default: KUBECONFIG
+    description: Environment variable name containing base64-encoded kubeconfig data
+    default: KUBECONFIG_DATA
 
 steps:
   - run:

--- a/src/examples/install-kubeconfig.yml
+++ b/src/examples/install-kubeconfig.yml
@@ -14,4 +14,4 @@ usage:
       steps:
         - checkout
         - kube-orb/install-kubeconfig:
-            kubeconfig: KUBECONFIG
+            kubeconfig: KUBECONFIG_DATA


### PR DESCRIPTION
This resolves https://github.com/CircleCI-Public/kubernetes-orb/issues/33 by:
- using a different default environment variable name for the `install-kubeconfig` command
- improving the documentation for the command

It also improves the tests for this command by testing the command with both the default and a non-default environment variable.