### PR TITLE
Add timeout to get rollout status

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -149,6 +149,7 @@ jobs:
 
 workflows:
   lint_pack-validate_publish-dev:
+    unless: << pipeline.parameters.run-integration-tests >>
     jobs:
       - orb-tools/lint
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,19 @@
 version: 2.1
 
 orbs:
-  orb-tools: circleci/orb-tools@8.3.0
+  orb-tools: circleci/orb-tools@9.2.1
   kube-orb: circleci/kubernetes@dev:alpha
+
+# Pipeline parameters
+parameters:
+  # These pipeline parameters are required by the "trigger-integration-tests-workflow"
+  # job, by default.
+  run-integration-tests:
+    type: boolean
+    default: false
+  dev-orb-version:
+    type: string
+    default: "dev:alpha"
 
 executors:
   ci-base:
@@ -133,21 +144,6 @@ jobs:
           kustomize: true
           now: true
           wait: true
-# yaml anchor filters
-integration-dev_filters: &integration-dev_filters
-  branches:
-    ignore: /.*/
-  tags:
-    only: /integration-.*/
-
-integration-master_filters: &integration-master_filters
-  branches:
-    ignore: /.*/
-  tags:
-    only: /master-.*/
-
-prod-deploy_requires: &prod-deploy_requires
-  [integration-test-docker-master, integration-test-machine-master, integration-test-macos-master, integration-test-kubectl-master]
 
 workflows:
   lint_pack-validate_publish-dev:
@@ -164,105 +160,34 @@ workflows:
           requires:
             - orb-tools/pack
 
-      - orb-tools/trigger-integration-workflow:
+      - orb-tools/trigger-integration-tests-workflow:
           name: trigger-integration-dev
           context: orb-publishing
-          ssh-fingerprints: 1b:26:fb:58:c5:a1:95:ef:13:93:11:4e:dd:42:41:2d
           requires:
             - orb-tools/publish-dev
-          filters:
-            branches:
-              ignore: master
 
-      - orb-tools/trigger-integration-workflow:
-          name: trigger-integration-master
+  integration-tests_prod-release:
+    when: << pipeline.parameters.run-integration-tests >>
+    jobs:
+      - integration-test-docker
+      - integration-test-machine
+      - integration-test-macos
+      - integration-test-kubectl
+
+      - orb-tools/dev-promote-prod-from-commit-subject:
+          orb-name: circleci/kubernetes
           context: orb-publishing
-          ssh-fingerprints: 1b:26:fb:58:c5:a1:95:ef:13:93:11:4e:dd:42:41:2d
-          tag: master
-          use-git-diff: false
-          static-release-type: minor
+          add-pr-comment: true
+          fail-if-semver-not-indicated: true
+          publish-version-tag: true
+          bot-token-variable: GHI_TOKEN
+          bot-user: cpe-bot
+          ssh-fingerprints: e0:f8:4b:34:54:de:74:23:af:7e:3d:39:28:cb:2f:7d
           requires:
-            - orb-tools/publish-dev
+            - integration-test-docker
+            - integration-test-machine
+            - integration-test-macos
+            - integration-test-kubectl
           filters:
             branches:
               only: master
-
-  integration-tests_prod-release:
-    jobs:
-      # non-master branch tests
-      - integration-test-docker:
-          name: integration-test-docker-dev
-          context: orb-publishing
-          filters: *integration-dev_filters
-
-      - integration-test-machine:
-          name: integration-test-machine-dev
-          context: orb-publishing
-          filters: *integration-dev_filters
-
-      - integration-test-macos:
-          name: integration-test-macos-dev
-          context: orb-publishing
-          filters: *integration-dev_filters
-
-      - integration-test-kubectl:
-          name: integration-test-kubectl-dev
-          context: orb-publishing
-          filters: *integration-dev_filters
-
-      # master-branch
-      - integration-test-docker:
-          name: integration-test-docker-master
-          context: orb-publishing
-          filters: *integration-master_filters
-
-      - integration-test-machine:
-          name: integration-test-machine-master
-          context: orb-publishing
-          filters: *integration-master_filters
-
-      - integration-test-macos:
-          name: integration-test-macos-master
-          context: orb-publishing
-          filters: *integration-master_filters
-
-      - integration-test-kubectl:
-          name: integration-test-kubectl-master
-          context: orb-publishing
-          filters: *integration-master_filters
-
-      # patch, minor, or major publishing
-      - orb-tools/dev-promote-prod:
-          name: dev-promote-patch
-          context: orb-publishing
-          orb-name: circleci/kubernetes
-          requires: *prod-deploy_requires
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /master-patch.*/
-
-      - orb-tools/dev-promote-prod:
-          name: dev-promote-minor
-          context: orb-publishing
-          orb-name: circleci/kubernetes
-          release: minor
-          requires: *prod-deploy_requires
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /master-minor.*/
-
-      - orb-tools/dev-promote-prod:
-          name: dev-promote-major
-          context: orb-publishing
-          orb-name: circleci/kubernetes
-          release: major
-          requires: *prod-deploy_requires
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /master-major.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,6 +39,8 @@ commands:
       - run:
           name: Start minikube
           command: |
+            sudo apt-get update
+            sudo apt-get install -y conntrack
             curl -Lo minikube https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64 \
               && chmod +x minikube
             sudo cp minikube /usr/local/bin && rm minikube

--- a/src/commands/create-or-update-resource.yml
+++ b/src/commands/create-or-update-resource.yml
@@ -52,6 +52,12 @@ parameters:
       Only effective if get-rollout-status is set to true.
     type: string
     default: ""
+  step-timeout:
+    description: |
+      The length of time to set no_output_timeout on the step,
+      this may be necessary if the rollout status takes longer than the default 10m
+    type: string
+    default: "10m"
   dry-run:
     description: |
       Whether the kubectl command will be executed in dry-run mode.
@@ -106,3 +112,4 @@ steps:
             watch-rollout-status: << parameters.watch-rollout-status >>
             pinned-revision-to-watch: << parameters.pinned-revision-to-watch >>
             watch-timeout: << parameters.watch-timeout >>
+            step-timeout: << parameters.step-timeout >>

--- a/src/commands/get-rollout-status.yml
+++ b/src/commands/get-rollout-status.yml
@@ -40,7 +40,7 @@ parameters:
 steps:
   - run:
       name: Show the resource rollout status
-      no_output_time: <<parameters.watch-timeout>>
+      no_output_timeout: <<parameters.watch-timeout>>
       command: |
         RESOURCE_NAME="<< parameters.resource-name >>"
         NAMESPACE="<< parameters.namespace >>"

--- a/src/commands/get-rollout-status.yml
+++ b/src/commands/get-rollout-status.yml
@@ -40,6 +40,7 @@ parameters:
 steps:
   - run:
       name: Show the resource rollout status
+      no_output_time: <<parameters.watch-timeout>>
       command: |
         RESOURCE_NAME="<< parameters.resource-name >>"
         NAMESPACE="<< parameters.namespace >>"

--- a/src/commands/get-rollout-status.yml
+++ b/src/commands/get-rollout-status.yml
@@ -31,6 +31,12 @@ parameters:
       Any other values should contain a corresponding time unit (e.g. 1s, 2m, 3h).
     type: string
     default: ""
+  step-timeout:
+    description: |
+      The length of time to set no_output_timeout on the step,
+      this may be necessary if the rollout status takes longer than the default 10m
+    type: string
+    default: "10m"
   show-kubectl-command:
     description: |
       Whether to show the kubectl command used.
@@ -40,7 +46,7 @@ parameters:
 steps:
   - run:
       name: Show the resource rollout status
-      no_output_timeout: <<parameters.watch-timeout>>
+      no_output_timeout: <<parameters.step-timeout>>
       command: |
         RESOURCE_NAME="<< parameters.resource-name >>"
         NAMESPACE="<< parameters.namespace >>"

--- a/src/commands/rollback.yml
+++ b/src/commands/rollback.yml
@@ -30,6 +30,12 @@ parameters:
       Any other values should contain a corresponding time unit (e.g. 1s, 2m, 3h).
     type: string
     default: ""
+  step-timeout:
+    description: |
+      The length of time to set no_output_timeout on the step,
+      this may be necessary if the rollout status takes longer than the default 10m
+    type: string
+    default: "10m"
   show-kubectl-command:
     description: |
       Whether to show the kubectl command used.
@@ -59,3 +65,4 @@ steps:
             namespace: << parameters.namespace >>
             watch-rollout-status: << parameters.watch-rollout-status >>
             watch-timeout: << parameters.watch-timeout >>
+            step-timeout: << parameters.step-timeout >>

--- a/src/commands/update-container-image.yml
+++ b/src/commands/update-container-image.yml
@@ -62,6 +62,12 @@ parameters:
       Only effective if get-rollout-status is set to true.
     type: string
     default: ""
+  step-timeout:
+    description: |
+      The length of time to set no_output_timeout on the step,
+      this may be necessary if the rollout status takes longer than the default 10m
+    type: string
+    default: "10m"
   dry-run:
     description: |
       Whether the kubectl command will be executed in dry-run mode.
@@ -112,3 +118,4 @@ steps:
             watch-rollout-status: << parameters.watch-rollout-status >>
             pinned-revision-to-watch: << parameters.pinned-revision-to-watch >>
             watch-timeout: << parameters.watch-timeout >>
+            step-timeout: << parameters.step-timeout >>


### PR DESCRIPTION
### Checklist

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues
Per, [this support article](https://support.circleci.com/hc/en-us/articles/360045268074-Build-Fails-with-Too-long-with-no-output-exceeded-10m0s-context-deadline-exceeded-), we need to also set no_output_time so the step doesn't timeout
https://github.com/CircleCI-Public/gcp-gke-orb/pull/31 is failing without it

### Description
use watch-timeout for no_output_time when getting rollout status