### PR TITLE
[semver:minor] Add server side apply option

### DIFF
--- a/src/commands/create-or-update-resource.yml
+++ b/src/commands/create-or-update-resource.yml
@@ -67,6 +67,12 @@ parameters:
       Whether to show the kubectl command used.
     type: boolean
     default: false
+  server-side-apply:
+    description: |
+      Whether to run apply in the server instead of the client.
+      Only effective if action-type is set to `apply`.
+    type: boolean
+    default: false
 
 steps:
   - run:
@@ -77,8 +83,13 @@ steps:
         NAMESPACE="<< parameters.namespace >>"
         DRY_RUN="<< parameters.dry-run >>"
         KUSTOMIZE="<< parameters.kustomize >>"
+        SERVER_SIDE_APPLY="<< parameters.server-side-apply >>"
         if [ -n "${ACTION_TYPE}" ]; then
           set -- "$@" "${ACTION_TYPE}"
+
+          if [ "${ACTION_TYPE}" == "apply" ] && [ "${SERVER_SIDE_APPLY}" == "true"]; then
+            set -- "$@" --server-side
+          fi
         fi
         if [ -n "${RESOURCE_FILE_PATH}" ]; then
           if [ "${KUSTOMIZE}" == "true" ]; then


### PR DESCRIPTION

**SEMVER Update Type:**
- [ ] Major
- [x] Minor
- [ ] Patch

## Description:
Add server-side option to `create-or-update-resource` command.

## Motivation:

It would be useful to have an option to opt-in server-side apply
https://kubernetes.io/docs/reference/using-api/server-side-apply/


## Checklist:

- [x] All new jobs, commands, executors, parameters have descriptions.
- [x] Usage Example version numbers have been updated.
- [ ] Changelog has been updated. => Unfortunately I was unable to find it. Could you kindly tell me where it is?