### PR TITLE
kubectl download sometimes take more than a minute

### DIFF
--- a/src/commands/install-kubectl.yml
+++ b/src/commands/install-kubectl.yml
@@ -24,7 +24,7 @@ steps:
         fi
 
         # download kubectl
-        curl -LO https://storage.googleapis.com/kubernetes-release/release/$KUBECTL_VERSION/bin/$PLATFORM/amd64/kubectl
+        curl --max-time 300 -LO https://storage.googleapis.com/kubernetes-release/release/$KUBECTL_VERSION/bin/$PLATFORM/amd64/kubectl
 
         [ -w /usr/local/bin ] && SUDO="" || SUDO=sudo
 


### PR DESCRIPTION
CircleCI has been slow in downloading the kubectl and failing our workflows. Example output:

```
# download kubectl
curl -LO https://storage.googleapis.com/kubernetes-release/release/$KUBECTL_VERSION/bin/$PLATFORM/amd64/kubectl

[ -w /usr/local/bin ] && SUDO="" || SUDO=sudo

$SUDO chmod +x ./kubectl

$SUDO mv ./kubectl /usr/local/bin

  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
 41 44.2M   41 18.4M    0     0   775k      0  0:00:58  0:00:24  0:00:34  814k
curl: (18) transfer closed with 27088048 bytes remaining to read

Exited with code exit status 18
CircleCI received exit code 18
```

This PR tells this `curl` to not time out for 300 seconds (6 minutes).