### PR TITLE
Update "dry-run" config in update-container-image

### DIFF
--- a/src/commands/update-container-image.yml
+++ b/src/commands/update-container-image.yml
@@ -65,8 +65,9 @@ parameters:
   dry-run:
     description: |
       Whether the kubectl command will be executed in dry-run mode.
-    type: boolean
-    default: false
+      Must be "none", "server", or "client"
+    type: string
+    default: "none"
   show-kubectl-command:
     description: |
       Whether to show the kubectl command used.


### PR DESCRIPTION
As mentioned in https://github.com/CircleCI-Public/kubernetes-orb/issues/51, With the latest version of KubeCtl (v1.23.0), they have removed support for boolean `dry-run` values. This just aims to bring the orb back in line with their requirements