### PR TITLE
[semver:major] Update flags in kubectl

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,7 +123,6 @@ jobs:
       - kubernetes/update-container-image:
           resource-name: "deployment/nginx-deployment"
           container-image-updates: "nginx=nginx:1.9.1 redis=redis:5-buster"
-          record: true
       - kubernetes/get-rollout-status:
           resource-name: "deployment/nginx-deployment"
           watch-rollout-status: true

--- a/src/commands/create-or-update-resource.yml
+++ b/src/commands/create-or-update-resource.yml
@@ -105,7 +105,6 @@ steps:
         # if [ -n "${DRY_RUN}" ]; then
         #   set -- "$@" --dry-run
         # fi
-        
         set -- "$@" --dry-run="$DRY_RUN"
         <<# parameters.show-kubectl-command >>set -x<</ parameters.show-kubectl-command >>
         kubectl "$@"

--- a/src/commands/create-or-update-resource.yml
+++ b/src/commands/create-or-update-resource.yml
@@ -102,9 +102,11 @@ steps:
         if [ -n "${NAMESPACE}" ]; then
             set -- "$@" --namespace="${NAMESPACE}"
         fi
-        if [ -n "${DRY_RUN}" ]; then
-          set -- "$@" --dry-run
-        fi
+        # if [ -n "${DRY_RUN}" ]; then
+        #   set -- "$@" --dry-run
+        # fi
+        
+        set -- "$@" --dry-run="$DRY_RUN"
         <<# parameters.show-kubectl-command >>set -x<</ parameters.show-kubectl-command >>
         kubectl "$@"
         <<# parameters.show-kubectl-command >>set +x<</ parameters.show-kubectl-command >>

--- a/src/commands/create-or-update-resource.yml
+++ b/src/commands/create-or-update-resource.yml
@@ -55,8 +55,8 @@ parameters:
   dry-run:
     description: |
       Whether the kubectl command will be executed in dry-run mode.
-    type: boolean
-    default: false
+    type: string
+    default: "none"
   kustomize:
     description: |
       Enable it to run the kubectl command with the option -k for kustomize.
@@ -102,7 +102,7 @@ steps:
         if [ -n "${NAMESPACE}" ]; then
             set -- "$@" --namespace="${NAMESPACE}"
         fi
-        if [ "${DRY_RUN}" == "true" ]; then
+        if [ -n "${DRY_RUN}" ]; then
           set -- "$@" --dry-run
         fi
         <<# parameters.show-kubectl-command >>set -x<</ parameters.show-kubectl-command >>

--- a/src/commands/create-or-update-resource.yml
+++ b/src/commands/create-or-update-resource.yml
@@ -56,8 +56,9 @@ parameters:
     description: |
       Whether the kubectl command will be executed in dry-run mode.
       Must be "none", "server", or "client"
-    type: string
+    type: enum
     default: "none"
+    enum: ["none", "server", "client"]
   kustomize:
     description: |
       Enable it to run the kubectl command with the option -k for kustomize.

--- a/src/commands/create-or-update-resource.yml
+++ b/src/commands/create-or-update-resource.yml
@@ -102,10 +102,7 @@ steps:
         if [ -n "${NAMESPACE}" ]; then
             set -- "$@" --namespace="${NAMESPACE}"
         fi
-        # if [ -n "${DRY_RUN}" ]; then
-        #   set -- "$@" --dry-run
-        # fi
-        set -- "$@" --dry-run="$DRY_RUN"
+        set -- "$@" --dry-run="${DRY_RUN}"
         <<# parameters.show-kubectl-command >>set -x<</ parameters.show-kubectl-command >>
         kubectl "$@"
         <<# parameters.show-kubectl-command >>set +x<</ parameters.show-kubectl-command >>

--- a/src/commands/create-or-update-resource.yml
+++ b/src/commands/create-or-update-resource.yml
@@ -55,6 +55,7 @@ parameters:
   dry-run:
     description: |
       Whether the kubectl command will be executed in dry-run mode.
+      Must be "none", "server", or "client"
     type: string
     default: "none"
   kustomize:

--- a/src/commands/delete-resource.yml
+++ b/src/commands/delete-resource.yml
@@ -48,8 +48,8 @@ parameters:
     description: |
       If true, cascades the deletion of the resources managed by this resource.
       (e.g. Pods created by a ReplicationController)
-    type: boolean
-    default: true
+    type: string
+    default: "background"
   force:
     description: |
       Only used when "0" is specified for grace-period. If true, immediately remove
@@ -154,10 +154,7 @@ steps:
         if [ -n "${NAMESPACE}" ]; then
             set -- "$@" --namespace="${NAMESPACE}"
         fi
-        # if [ "${DRY_RUN}" == "true" ]; then
-        #   set -- "$@" --dry-run
-        # fi
-        set -- "$@" --dry-run="$DRY_RUN"
+        set -- "$@" --dry-run="${DRY_RUN}"
         set -- "$@" --wait="${WAIT}"
         set -- "$@" --cascade="${CASCADE}"
         <<# parameters.show-kubectl-command >>set -x<</ parameters.show-kubectl-command >>

--- a/src/commands/delete-resource.yml
+++ b/src/commands/delete-resource.yml
@@ -89,8 +89,8 @@ parameters:
   dry-run:
     description: |
       Whether the kubectl command will be executed in dry-run mode.
-    type: boolean
-    default: false
+    type: string
+    default: "none"
   kustomize:
     description: |
       Enable it to run the kubectl command with the option -k for kustomize.
@@ -154,9 +154,10 @@ steps:
         if [ -n "${NAMESPACE}" ]; then
             set -- "$@" --namespace="${NAMESPACE}"
         fi
-        if [ "${DRY_RUN}" == "true" ]; then
-          set -- "$@" --dry-run
-        fi
+        # if [ "${DRY_RUN}" == "true" ]; then
+        #   set -- "$@" --dry-run
+        # fi
+        set -- "$@" --dry-run="$DRY_RUN"
         set -- "$@" --wait="${WAIT}"
         set -- "$@" --cascade="${CASCADE}"
         <<# parameters.show-kubectl-command >>set -x<</ parameters.show-kubectl-command >>

--- a/src/commands/delete-resource.yml
+++ b/src/commands/delete-resource.yml
@@ -48,6 +48,7 @@ parameters:
     description: |
       If true, cascades the deletion of the resources managed by this resource.
       (e.g. Pods created by a ReplicationController)
+      Must be "background" or "foreground"
     type: string
     default: "background"
   force:
@@ -89,6 +90,7 @@ parameters:
   dry-run:
     description: |
       Whether the kubectl command will be executed in dry-run mode.
+      Must be "none", "server", or "client"
     type: string
     default: "none"
   kustomize:

--- a/src/commands/delete-resource.yml
+++ b/src/commands/delete-resource.yml
@@ -49,8 +49,9 @@ parameters:
       If true, cascades the deletion of the resources managed by this resource.
       (e.g. Pods created by a ReplicationController)
       Must be "background" or "foreground"
-    type: string
+    type: enum
     default: "background"
+    enum: ["background", "foreground"]
   force:
     description: |
       Only used when "0" is specified for grace-period. If true, immediately remove
@@ -91,8 +92,9 @@ parameters:
     description: |
       Whether the kubectl command will be executed in dry-run mode.
       Must be "none", "server", or "client"
-    type: string
+    type: enum
     default: "none"
+    enum: ["none", "server", "client"]
   kustomize:
     description: |
       Enable it to run the kubectl command with the option -k for kustomize.

--- a/src/commands/update-container-image.yml
+++ b/src/commands/update-container-image.yml
@@ -60,8 +60,9 @@ parameters:
   dry-run:
     description: |
       Whether the kubectl command will be executed in dry-run mode.
-    type: string
+    type: enum
     default: "none"
+    enum: ["none", "server", "client"]
   show-kubectl-command:
     description: |
       Whether to show the kubectl command used.

--- a/src/commands/update-container-image.yml
+++ b/src/commands/update-container-image.yml
@@ -65,8 +65,8 @@ parameters:
   dry-run:
     description: |
       Whether the kubectl command will be executed in dry-run mode.
-    type: boolean
-    default: false
+    type: string
+    default: "none"
   show-kubectl-command:
     description: |
       Whether to show the kubectl command used.

--- a/src/commands/update-container-image.yml
+++ b/src/commands/update-container-image.yml
@@ -30,11 +30,6 @@ parameters:
       The kubernetes namespace that should be used.
     type: string
     default: ""
-  record:
-    description: |
-      Whether to record the update
-    type: boolean
-    default: false
   get-rollout-status:
     description: |
       Get the status of the rollout.
@@ -81,7 +76,6 @@ steps:
         RESOURCE_NAME="<< parameters.resource-name >>"
         CONTAINER_IMAGE_UPDATES="<< parameters.container-image-updates >>"
         NAMESPACE="<< parameters.namespace >>"
-        RECORD="<< parameters.record >>"
         DRY_RUN="<< parameters.dry-run >>"
         if [ -n "${RESOURCE_FILE_PATH}" ]; then
           set -- "$@" -f
@@ -98,7 +92,6 @@ steps:
         if [ -n "${NAMESPACE}" ]; then
           set -- "$@" --namespace="${NAMESPACE}"
         fi
-        set -- "$@" "--record=${RECORD}"
         set -- "$@" "--dry-run=${DRY_RUN}"
         <<# parameters.show-kubectl-command >>set -x<</ parameters.show-kubectl-command >>
         kubectl set image "$@"

--- a/src/examples/deployment-update.yml
+++ b/src/examples/deployment-update.yml
@@ -18,4 +18,3 @@ usage:
             resource-name: "deployment/nginx-deployment"
             container-image-updates: "nginx=nginx:1.9.1"
             get-rollout-status: true
-            record: true


### PR DESCRIPTION
- Updated `dry-run` flag to type enum and made default value "none"
- Updated `cascade` flag to type enum and made default value "background"
- Removed deprecated `record` flag