### PR TITLE
Fix show-kubectl-command parameter

### DIFF
--- a/src/commands/create-or-update-resource.yml
+++ b/src/commands/create-or-update-resource.yml
@@ -90,6 +90,7 @@ steps:
         PARAM_NAMESPACE: << parameters.namespace >>
         PARAM_DRY_RUN: << parameters.dry-run >>
         PARAM_KUSTOMIZE: << parameters.kustomize >>
+        PARAM_SHOW_KUBECTL_COMMAND: << parameters.show-kubectl-command >>
         PARAM_SERVER_SIDE_APPLY: << parameters.server-side-apply >>
         PARAM_ENVSUBST: << parameters.envsubst >>
       command: <<include(scripts/create-or-update-resource.sh)>>
@@ -102,3 +103,4 @@ steps:
             watch-rollout-status: << parameters.watch-rollout-status >>
             pinned-revision-to-watch: << parameters.pinned-revision-to-watch >>
             watch-timeout: << parameters.watch-timeout >>
+            show-kubectl-command: << parameters.show-kubectl-command >>

--- a/src/commands/delete-resource.yml
+++ b/src/commands/delete-resource.yml
@@ -124,4 +124,5 @@ steps:
         PARAM_NAMESPACE: << parameters.namespace >>
         PARAM_DRY_RUN: << parameters.dry-run >>
         PARAM_KUSTOMIZE: << parameters.kustomize >>
+        PARAM_SHOW_KUBECTL_COMMAND: << parameters.show_kubectl_command >>
       command: <<include(scripts/delete-resource.sh)>>

--- a/src/commands/get-rollout-status.yml
+++ b/src/commands/get-rollout-status.yml
@@ -52,6 +52,7 @@ steps:
         PARAM_WATCH_ROLLOUT_STATUS: << parameters.watch-rollout-status >>
         PARAM_PINNED_REVISION_TO_WATCH: << parameters.pinned-revision-to-watch >>
         PARAM_WATCH_TIMEOUT: << parameters.watch-timeout >>
+        PARAM_SHOW_KUBECTL_COMMAND: << parameters.show_kubectl_command >>
         PARAM_RESOURCE_FILE_PATH: << parameters.resource-file-path >>
       command: <<include(scripts/get-rollout-status.sh)>>
   - run:
@@ -59,5 +60,6 @@ steps:
       environment:
         PARAM_RESOURCE_NAME: << parameters.resource-name >>
         PARAM_NAMESPACE: << parameters.namespace >>
+        PARAM_SHOW_KUBECTL_COMMAND: << parameters.show_kubectl_command >>
         PARAM_RESOURCE_FILE_PATH: << parameters.resource-file-path >>
       command: <<include(scripts/describe.sh)>>

--- a/src/commands/rollback.yml
+++ b/src/commands/rollback.yml
@@ -42,6 +42,7 @@ steps:
       environment:
         PARAM_RESOURCE_NAME: << parameters.resource-name >>
         PARAM_NAMESPACE: << parameters.namespace >>
+        PARAM_SHOW_KUBECTL_COMMAND: << parameters.show_kubectl_command >>
       command: <<include(scripts/rollback.sh)>>
   - when:
       condition: << parameters.get-rollout-status >>
@@ -51,3 +52,4 @@ steps:
             namespace: << parameters.namespace >>
             watch-rollout-status: << parameters.watch-rollout-status >>
             watch-timeout: << parameters.watch-timeout >>
+            show-kubectl-command: << parameters.show-kubectl-command >>

--- a/src/commands/update-container-image.yml
+++ b/src/commands/update-container-image.yml
@@ -77,6 +77,7 @@ steps:
         PARAM_RESOURCE_NAME: << parameters.resource-name >>
         PARAM_CONTAINER_IMAGE_UPDATES: << parameters.container-image-updates >>
         PARAM_NAMESPACE: << parameters.namespace >>
+        PARAM_SHOW_KUBECTL_COMMAND: << parameters.show-kubectl-command >>
       command: <<include(scripts/update-container-image.sh)>>
   - when:
       condition: << parameters.get-rollout-status >>
@@ -87,3 +88,4 @@ steps:
             watch-rollout-status: << parameters.watch-rollout-status >>
             pinned-revision-to-watch: << parameters.pinned-revision-to-watch >>
             watch-timeout: << parameters.watch-timeout >>
+            show-kubectl-command: << parameters.show-kubectl-command >>

--- a/src/scripts/create-or-update-resource.sh
+++ b/src/scripts/create-or-update-resource.sh
@@ -4,6 +4,7 @@ ACTION_TYPE=$(eval echo "$PARAM_ACTION_TYPE")
 NAMESPACE=$(eval echo "$PARAM_NAMESPACE")
 DRY_RUN=$(eval echo "$PARAM_DRY_RUN")
 KUSTOMIZE=$(eval echo "$PARAM_KUSTOMIZE")
+SHOW_KUBECTL_COMMAND=$(eval echo "$PARAM_SHOW_KUBECTL_COMMAND")
 SERVER_SIDE_APPLY=$(eval echo "$PARAM_SERVER_SIDE_APPLY")
 ENVSUBST=$(eval echo "$PARAM_ENVSUBST")
 
@@ -35,10 +36,10 @@ fi
 if [ -n "${DRY_RUN}" ]; then
     set -- "$@" --dry-run="${DRY_RUN}"
 fi
-if [ "$SHOW_EKSCTL_COMMAND" == "1" ]; then
+if [ "$SHOW_KUBECTL_COMMAND" == "1" ]; then
     set -x
 fi
 kubectl "$@"
-if [ "$SHOW_EKSCTL_COMMAND" == "1" ]; then
+if [ "$SHOW_KUBECTL_COMMAND" == "1" ]; then
     set +x
 fi

--- a/src/scripts/delete-resource.sh
+++ b/src/scripts/delete-resource.sh
@@ -13,6 +13,8 @@ WAIT=$(eval echo "$PARAM_WAIT")
 NAMESPACE=$(eval echo "$PARAM_NAMESPACE")
 DRY_RUN=$(eval echo "$PARAM_DRY_RUN")
 KUSTOMIZE=$(eval echo "$PARAM_KUSTOMIZE")
+SHOW_KUBECTL_COMMAND=$(eval echo "$PARAM_SHOW_KUBECTL_COMMAND")
+
 if [ -n "${RESOURCE_FILE_PATH}" ]; then
     if [ "${KUSTOMIZE}" == "1" ]; then
     set -- "$@" -k
@@ -52,10 +54,10 @@ if [ -n "${DRY_RUN}" ]; then
 fi
 set -- "$@" --wait="${WAIT}"
 set -- "$@" --cascade="${CASCADE}"
-if [ "$SHOW_EKSCTL_COMMAND" == "1" ]; then
+if [ "$SHOW_KUBECTL_COMMAND" == "1" ]; then
     set -x
 fi
 kubectl delete "$@"
-if [ "$SHOW_EKSCTL_COMMAND" == "1" ]; then
+if [ "$SHOW_KUBECTL_COMMAND" == "1" ]; then
     set +x
 fi

--- a/src/scripts/describe.sh
+++ b/src/scripts/describe.sh
@@ -1,26 +1,27 @@
 #!/bin/bash
 RESOURCE_NAME=$(eval echo "$PARAM_RESOURCE_NAME")
 NAMESPACE=$(eval echo "$PARAM_NAMESPACE")
+SHOW_KUBECTL_COMMAND=$(eval echo "$PARAM_SHOW_KUBECTL_COMMAND")
 RESOURCE_FILE_PATH=$(eval echo "$PARAM_RESOURCE_FILE_PATH")
+
+
 if [ -n "${RESOURCE_FILE_PATH}" ]; then
-    if [ "$SHOW_EKSCTL_COMMAND" == "1" ]; then
+    if [ "$SHOW_KUBECTL_COMMAND" == "1" ]; then
     set -x
     fi
     kubectl describe -f "${RESOURCE_FILE_PATH}"
-    if [ "$SHOW_EKSCTL_COMMAND" == "1" ]; then
+    if [ "$SHOW_KUBECTL_COMMAND" == "1" ]; then
         set +x
     fi
 else
     if [ -n "${NAMESPACE}" ]; then
         set -- "$@" "--namespace=${NAMESPACE}"
     fi
-    if [ "$SHOW_EKSCTL_COMMAND" == "1" ]; then
+    if [ "$SHOW_KUBECTL_COMMAND" == "1" ]; then
         set -x
     fi
     kubectl describe "${RESOURCE_NAME}" "$@"
-    if [ "$SHOW_EKSCTL_COMMAND" == "1" ]; then
+    if [ "$SHOW_KUBECTL_COMMAND" == "1" ]; then
         set +x
     fi
 fi
-
-

--- a/src/scripts/get-rollout-status.sh
+++ b/src/scripts/get-rollout-status.sh
@@ -4,14 +4,15 @@ NAMESPACE=$(eval echo "$PARAM_NAMESPACE")
 WATCH_ROLLOUT_STATUS=$(eval echo "$PARAM_WATCH_ROLLOUT_STATUS")
 PINNED_REVISION_TO_WATCH=$(eval echo "$PARAM_PINNED_REVISION_TO_WATCH")
 WATCH_TIMEOUT=$(eval echo "$PARAM_WATCH_TIMEOUT")
+SHOW_KUBECTL_COMMAND=$(eval echo "$PARAM_SHOW_KUBECTL_COMMAND")
 RESOURCE_FILE_PATH=$(eval echo "$PARAM_RESOURCE_FILE_PATH")
 
 if [ -n "$RESOURCE_FILE_PATH" ]; then
-    if [ "$SHOW_EKSCTL_COMMAND" == "1" ]; then
+    if [ "$SHOW_KUBECTL_COMMAND" == "1" ]; then
     set -x
     fi
     kubectl rollout status -f "$RESOURCE_FILE_PATH"
-    if [ "$SHOW_EKSCTL_COMMAND" == "1" ]; then
+    if [ "$SHOW_KUBECTL_COMMAND" == "1" ]; then
         set +x
     fi
 else 
@@ -30,12 +31,11 @@ else
         set -- "$@" "--timeout=${WATCH_TIMEOUT}"
         fi
     fi
-    if [ "$SHOW_EKSCTL_COMMAND" == "1" ]; then
+    if [ "$SHOW_KUBECTL_COMMAND" == "1" ]; then
         set -x
     fi
     kubectl rollout status "$@"
-    if [ "$SHOW_EKSCTL_COMMAND" == "1" ]; then
+    if [ "$SHOW_KUBECTL_COMMAND" == "1" ]; then
         set +x
     fi
 fi
-

--- a/src/scripts/rollback.sh
+++ b/src/scripts/rollback.sh
@@ -1,16 +1,18 @@
 #!/bin/bash
 RESOURCE_NAME=$(eval echo "$PARAM_RESOURCE_NAME")
 NAMESPACE=$(eval echo "$PARAM_NAMESPACE")
+SHOW_KUBECTL_COMMAND=$(eval echo "$PARAM_SHOW_KUBECTL_COMMAND")
+
 if [ -n "${RESOURCE_NAME}" ]; then
     set -- "$@" "${RESOURCE_NAME}"
 fi
 if [ -n "${NAMESPACE}" ]; then
     set -- "$@" "--namespace=${NAMESPACE}"
 fi
-if [ "$SHOW_EKSCTL_COMMAND" == "1" ]; then
+if [ "$SHOW_KUBECTL_COMMAND" == "1" ]; then
     set -x
 fi
 kubectl rollout undo "$@"
-if [ "$SHOW_EKSCTL_COMMAND" == "1" ]; then
+if [ "$SHOW_KUBECTL_COMMAND" == "1" ]; then
     set +x
 fi

--- a/src/scripts/update-container-image.sh
+++ b/src/scripts/update-container-image.sh
@@ -4,6 +4,8 @@ RESOURCE_NAME=$(eval echo "$PARAM_RESOURCE_NAME")
 CONTAINER_IMAGE_UPDATES=$(eval echo "$PARAM_CONTAINER_IMAGE_UPDATES")
 NAMESPACE=$(eval echo "$PARAM_NAMESPACE")
 DRY_RUN=$(eval echo "$PARAM_DRY_RUN")
+SHOW_KUBECTL_COMMAND=$(eval echo "$PARAM_SHOW_KUBECTL_COMMAND")
+
 if [ -n "${RESOURCE_FILE_PATH}" ]; then
     set -- "$@" -f
     set -- "$@" "${RESOURCE_FILE_PATH}"
@@ -22,10 +24,10 @@ fi
 if [ -n "${DRY_RUN}" ]; then
     set -- "$@" --dry-run "${DRY_RUN}"
 fi
-if [ "$SHOW_EKSCTL_COMMAND" == "1" ]; then
+if [ "$SHOW_KUBECTL_COMMAND" == "1" ]; then
     set -x
 fi
 kubectl set image "$@"
-if [ "$SHOW_EKSCTL_COMMAND" == "1" ]; then
+if [ "$SHOW_KUBECTL_COMMAND" == "1" ]; then
     set +x
 fi


### PR DESCRIPTION
Currently, `show-kubectl-command` is exposed as a parmater for a bunch of commands, to show the "`kubectl` command[sic, should be plural], however it is broken, because (a) the parameter is not propagated and (b) the parameter has a different name (`SHOW_EKSCTL_COMMAND`). This PR fixes these things so that `show-kubectl-command` parameter actually works.