### PR TITLE
Support arm64

### DIFF
--- a/src/commands/install-kops.yml
+++ b/src/commands/install-kops.yml
@@ -1,6 +1,6 @@
 description: |
   Installs kops (latest release, by default)
-  Requirements: curl, amd64 architecture
+  Requirements: curl
 
 parameters:
   kops-version:

--- a/src/commands/install-kubectl.yml
+++ b/src/commands/install-kubectl.yml
@@ -1,6 +1,6 @@
 description: |
   Installs kubectl (latest release, by default)
-  Requirements: curl, amd64 architecture
+  Requirements: curl
 
 parameters:
   kubectl-version:

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -1,6 +1,6 @@
 description: |
   Installs kubectl and kops (latest releases, by default)
-  Requirements: curl, amd64 architecture
+  Requirements: curl
 
 parameters:
   kops-version:

--- a/src/scripts/install-kops.sh
+++ b/src/scripts/install-kops.sh
@@ -10,8 +10,13 @@ if [ -n "$(uname | grep "Darwin")" ]; then
     PLATFORM="darwin"
 fi
 
+ARCH="arm64"
+if [ "$(uname -m)" == "x86_64" ]; then
+    ARCH="amd64"
+fi
+
 # download kops
-curl -Lo kops https://github.com/kubernetes/kops/releases/download/$KOPS_VERSION/kops-$PLATFORM-amd64
+curl -Lo kops https://github.com/kubernetes/kops/releases/download/$KOPS_VERSION/kops-$PLATFORM-${ARCH}
 
 [ -w /usr/local/bin ] && SUDO="" || SUDO=sudo
 

--- a/src/scripts/install-kubectl.sh
+++ b/src/scripts/install-kubectl.sh
@@ -11,11 +11,16 @@ if [ -n "$(uname | grep "Darwin")" ]; then
     PLATFORM="darwin"
 fi
 
+ARCH="arm64"
+if [ "$(uname -m)" == "x86_64" ]; then
+    ARCH="amd64"
+fi
+
 # download kubectl
 if [ "$MAX_TIME" == "1" ]; then
-    curl --max-time 300 -LO https://storage.googleapis.com/kubernetes-release/release/$KUBECTL_VERSION/bin/$PLATFORM/amd64/kubectl
+    curl --max-time 300 -LO https://storage.googleapis.com/kubernetes-release/release/$KUBECTL_VERSION/bin/$PLATFORM/${ARCH}/kubectl
 else 
-    curl -LO https://storage.googleapis.com/kubernetes-release/release/$KUBECTL_VERSION/bin/$PLATFORM/amd64/kubectl
+    curl -LO https://storage.googleapis.com/kubernetes-release/release/$KUBECTL_VERSION/bin/$PLATFORM/${ARCH}/kubectl
 fi
 
 [ -w /usr/local/bin ] && SUDO="" || SUDO=sudo


### PR DESCRIPTION
Circle now has machine executors for ARM; this PR will allow the
kubernetes orb to be used on those executors. (As well as on docker ARM
executors, if CircleCI offers those in the future.)