### PR TITLE
feat: arm64 support for kubectl and kops

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -172,6 +172,8 @@ jobs:
 workflows:
   test-deploy:
     jobs:
+      - integration-test-arm:
+          filters: *filters
       - integration-test-docker:
           filters: *filters
       - integration-test-machine:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -26,6 +26,11 @@ executors:
     environment:
       CHANGE_MINIKUBE_NONE_USER=true
 
+  arm:
+    machine:
+      image: ubuntu-2204:2022.07.1
+    resource_class: arm.medium
+
   macos:
     macos:
       xcode: 14.2.0
@@ -111,6 +116,14 @@ jobs:
 
   integration-test-macos:
     executor: macos
+    environment:
+      # For testing the install_kubeconfig command
+      MY_KUBECONFIG_DATA: dGVzdA==
+    steps:
+      - integration-tests
+
+  integration-test-arm:
+    executor: arm
     environment:
       # For testing the install_kubeconfig command
       MY_KUBECONFIG_DATA: dGVzdA==

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -1,6 +1,6 @@
 description: |
   Installs kubectl and kops (latest releases, by default)
-  Requirements: curl, amd64 architecture
+  Requirements: curl
 
 parameters:
   kops_version:

--- a/src/commands/install_kops.yml
+++ b/src/commands/install_kops.yml
@@ -1,6 +1,6 @@
 description: |
   Installs kops (latest release, by default)
-  Requirements: curl, amd64 architecture
+  Requirements: curl
 
 parameters:
   kops_version:

--- a/src/commands/install_kubectl.yml
+++ b/src/commands/install_kubectl.yml
@@ -1,6 +1,6 @@
 description: |
   Installs kubectl (latest release, by default)
-  Requirements: curl, amd64 architecture
+  Requirements: curl
 
 parameters:
   kubectl_version:

--- a/src/scripts/install_kops.sh
+++ b/src/scripts/install_kops.sh
@@ -10,8 +10,12 @@ if uname | grep "Darwin"; then
     PLATFORM="darwin"
 fi
 
+ARCH="arm64"
+if uname -m | grep "x86_64"; then
+    ARCH="amd64"
+fi
 # download kops
-curl -Lo kops https://github.com/kubernetes/kops/releases/download/"${KOPS_VERSION}"/kops-"${PLATFORM}"-amd64
+curl -Lo kops https://github.com/kubernetes/kops/releases/download/"${KOPS_VERSION}"/kops-"${PLATFORM}"-"${ARCH}"
 
 [ -w /usr/local/bin ] && SUDO="" || SUDO=sudo
 

--- a/src/scripts/install_kubectl.sh
+++ b/src/scripts/install_kubectl.sh
@@ -11,11 +11,16 @@ if uname | grep "Darwin"; then
     PLATFORM="darwin"
 fi
 
+ARCH="arm64"
+if uname -m | grep "x86_64"; then
+    ARCH="amd64"
+fi
+
 # download kubectl
 if [ "$MAX_TIME" == "1" ]; then
-    curl --max-time 300 -LO https://storage.googleapis.com/kubernetes-release/release/"${KUBECTL_VERSION}"/bin/"${PLATFORM}"/amd64/kubectl
+    curl --max-time 300 -LO https://storage.googleapis.com/kubernetes-release/release/"${KUBECTL_VERSION}"/bin/"${PLATFORM}"/"${ARCH}"/kubectl
 else 
-    curl -LO https://storage.googleapis.com/kubernetes-release/release/"${KUBECTL_VERSION}"/bin/"${PLATFORM}"/amd64/kubectl
+    curl -LO https://storage.googleapis.com/kubernetes-release/release/"${KUBECTL_VERSION}"/bin/"${PLATFORM}"/"${ARCH}"/kubectl
 fi
 
 [ -w /usr/local/bin ] && SUDO="" || SUDO=sudo


### PR DESCRIPTION
Currently, we only support `amd64` architecture for kops and kubectl. This pull request adds support `arm64`. 