### PR TITLE
fix: add version validation for kubectl

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -78,7 +78,7 @@ commands:
     steps:
       - checkout
       - kubernetes/install:
-          kubectl_version: v1.15.2
+          kubectl_version: "1.15.2"
           kops_version: 1.12.2
           max_time: true
       - run:
@@ -173,23 +173,23 @@ jobs:
 workflows:
   test-deploy:
     jobs:
-      - integration-test-arm:
-          filters: *filters
-      - integration-test-docker:
-          filters: *filters
+      # - integration-test-arm:
+      #     filters: *filters
+      # - integration-test-docker:
+      #     filters: *filters
       - integration-test-machine:
           filters: *filters
-      - integration-test-macos:
-          filters: *filters
-      - integration-test-kubectl:
-          filters: *filters
-      - orb-tools/pack:
-          filters: *release-filters
-      - orb-tools/publish:
-          orb_name: circleci/kubernetes
-          vcs_type: << pipeline.project.type >>
-          pub_type: production
-          enable_pr_comment: true
-          context: orb-publisher
-          requires: [ orb-tools/pack, integration-test-docker, integration-test-machine, integration-test-macos, integration-test-kubectl ]
-          filters: *release-filters
+      # - integration-test-macos:
+      #     filters: *filters
+      # - integration-test-kubectl:
+      #     filters: *filters
+      # - orb-tools/pack:
+      #     filters: *release-filters
+      # - orb-tools/publish:
+      #     orb_name: circleci/kubernetes
+      #     vcs_type: << pipeline.project.type >>
+      #     pub_type: production
+      #     enable_pr_comment: true
+      #     context: orb-publisher
+      #     requires: [ orb-tools/pack, integration-test-docker, integration-test-machine, integration-test-macos, integration-test-kubectl ]
+      #     filters: *release-filters

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -78,7 +78,7 @@ commands:
     steps:
       - checkout
       - kubernetes/install:
-          kubectl_version: "1.15.2"
+          kubectl_version: "v1.15.2"
           kops_version: 1.12.2
           max_time: true
       - run:
@@ -173,23 +173,23 @@ jobs:
 workflows:
   test-deploy:
     jobs:
-      # - integration-test-arm:
-      #     filters: *filters
-      # - integration-test-docker:
-      #     filters: *filters
+      - integration-test-arm:
+          filters: *filters
+      - integration-test-docker:
+          filters: *filters
       - integration-test-machine:
           filters: *filters
-      # - integration-test-macos:
-      #     filters: *filters
-      # - integration-test-kubectl:
-      #     filters: *filters
-      # - orb-tools/pack:
-      #     filters: *release-filters
-      # - orb-tools/publish:
-      #     orb_name: circleci/kubernetes
-      #     vcs_type: << pipeline.project.type >>
-      #     pub_type: production
-      #     enable_pr_comment: true
-      #     context: orb-publisher
-      #     requires: [ orb-tools/pack, integration-test-docker, integration-test-machine, integration-test-macos, integration-test-kubectl ]
-      #     filters: *release-filters
+      - integration-test-macos:
+          filters: *filters
+      - integration-test-kubectl:
+          filters: *filters
+      - orb-tools/pack:
+          filters: *release-filters
+      - orb-tools/publish:
+          orb_name: circleci/kubernetes
+          vcs_type: << pipeline.project.type >>
+          pub_type: production
+          enable_pr_comment: true
+          context: orb-publisher
+          requires: [ orb-tools/pack, integration-test-docker, integration-test-machine, integration-test-macos, integration-test-kubectl ]
+          filters: *release-filters

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -7,6 +7,8 @@ parameters:
     type: string
     default: "latest"
   kubectl_version:
+    description: |
+      specify version using vX.Y.Z (e.g., v1.29.0) format.
     type: string
     default: "latest"
   max_time:

--- a/src/commands/install_kubectl.yml
+++ b/src/commands/install_kubectl.yml
@@ -5,7 +5,7 @@ description: |
 parameters:
   kubectl_version:
     description: |
-      specify version using "v1.xx" format
+      specify version using vX.Y.Z (e.g., v1.29.0) format.
     type: string
     default: "latest"
   max_time:

--- a/src/commands/install_kubectl.yml
+++ b/src/commands/install_kubectl.yml
@@ -4,6 +4,8 @@ description: |
 
 parameters:
   kubectl_version:
+    description: |
+      specify version using "v1.xx" format
     type: string
     default: "latest"
   max_time:

--- a/src/scripts/install_kubectl.sh
+++ b/src/scripts/install_kubectl.sh
@@ -6,6 +6,14 @@ if [ "$KUBECTL_VERSION" == "latest" ]; then
     KUBECTL_VERSION=$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)
 fi
 
+if [[ $KUBECTL_VERSION =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "Valid version format."
+else
+  echo "Invalid version format: ${KUBECTL_VERSION}" 
+  echo "Please use the format vX.Y.Z (e.g., v1.29.0)."
+  exit 1
+fi
+
 PLATFORM="linux"
 if uname | grep "Darwin"; then
     PLATFORM="darwin"

--- a/src/scripts/install_kubectl.sh
+++ b/src/scripts/install_kubectl.sh
@@ -6,7 +6,7 @@ if [ "$KUBECTL_VERSION" == "latest" ]; then
     KUBECTL_VERSION=$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)
 fi
 
-if [[ $KUBECTL_VERSION =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+if [[ "$KUBECTL_VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
   echo "Valid version format."
 else
   echo "Invalid version format: ${KUBECTL_VERSION}" 


### PR DESCRIPTION
Currently when a user installs kubectl and specifies a version, they need to provide it with this format: `vX.Y.Z`

If the version is in the wrong format, the command still passes and fails when the actual `kubectl` command is invoked. 

This pull request adds validation for the version provided by the user. If the version is not properly formatted, it fails immediately, 